### PR TITLE
[NFP-2] Support multiple opCenter in address.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,16 +38,16 @@ Go to the folder where you just install the `nextflow` command line.
 Let's call this folder the Nextflow home directory.
 Create the float plugin folder with:
 ```
-mkdir -p .nextflow/plugins/nf-float-0.1.1
+mkdir -p .nextflow/plugins/nf-float-0.1.2
 ```
-where `0.1.1` is the version of the float plugin.  This version number should 
+where `0.1.2` is the version of the float plugin.  This version number should 
 align with the version in of your plugin and the property in your configuration
 file. (check the configuration section)
 
 Retrieve your plugin zip file and unzip it in this folder.
 If everything goes right, you should be able to see two sub-folders:
 ```
-$ ll .nextflow/plugins/nf-float-0.1.1/
+$ ll .nextflow/plugins/nf-float-0.1.2/
 total 48
 drwxr-xr-x 4 ec2-user ec2-user    51 Jan  5 07:17 classes
 drwxr-xr-x 2 ec2-user ec2-user    25 Jan  5 07:17 META-INF
@@ -60,13 +60,13 @@ file with the command line option `-c`.  Here is a sample of the configuration.
 
 ```
 plugins {
-    id 'nf-float@0.1.1'
+    id 'nf-float@0.1.2'
 }
 
 workDir = '/mnt/memverge/shared'
 
 float {
-    address = 'ec2-3-142-124-0.us-east-2.compute.amazonaws.com'
+    address = 'opcenter.compute.amazonaws.com'
     username = 'admin'
     password = 'memverge'
     nfs = 'nfs://1.2.3.4/mnt/memverge/shared'
@@ -77,19 +77,24 @@ float {
 * `workDir` is where we mount the NFS and where Nextflow put the process files.
 * In the `float` section, users must supply the address of the MMCE operation
   center and the proper credentials.
-  * `address` address of your operation center
+  * `address` address of your operation center(s).  Separate multiple addresses with `,`.
   * `username` and `password` are the credentials for your operation center
   * `nfs` points to the location of the NFS.
-  * `image` is an optional property that specifies the default image for a float process.
-  * `cpu` is an optional property that specifies the default number of CPU cores
-    for a float process, the default value is `2`.
-  * `mem` is an optional property that specifies the default size of memory for a
+  * `image` (deprecated) is an optional property that specifies the default image for a float process.
+  * `container` is an optional property that specifies the default image for a float process.
+  * `cpu` (deprecated) is an optional property that specifies the default number of 
+    CPU cores for a float process, the default value is `2`.
+  * `cpus` is an optional property that specifies the default number of
+    CPU cores for a float process, the default value is `2`.
+  * `mem` (deprecated) is an optional property that specifies the default size of memory for a
     float process in GB.  The default value is `4`.
+  * `memory` is an optional property that specifies the default size of memory for a
+    float process in GB.  The default value is `'4 GB'`.
   * `commonExtra` allows the user to specify other submit parameters.  This parameter
     will be appended to every float submit command.
 
 ## Task Sample
-
+[FloatGridExecutor.groovy](plugins%2Fnf-float%2Fsrc%2Fmain%2Fcom%2Fmemverge%2Fnextflow%2FFloatGridExecutor.groovy)
 For each process, users could supply their requirements for the CPU, memory and image.
 Here is an example of a hello world workflow.
 
@@ -114,9 +119,12 @@ workflow {
 ```
 
 * `executor = 'float'` - tells Nextflow to run the workflow with `float`.
-* `cpu` - specifies the number of cores required by this process.
-* `mem` - specifies the number of memory required by this process in GB.
-* `image` - is the name of the container image.
+* `cpu` - (deprecated) specifies the number of cores required by this process.
+* `cpus` - specifies the number of cores required by this process.
+* `mem` - (deprecated) specifies the number of memory required by this process in GB.
+* `memory` specify the memories.  Note that the value is a string, such as `'5 GB'`
+* `image` - (deprecated) is the name of the container image.
+* `contaner` - the same as `image`
 * `extra` - specifies extra parameters for the job.  It will be merged with
             the `commonExtra` parameter. 
 

--- a/conf/float-rt.conf
+++ b/conf/float-rt.conf
@@ -1,5 +1,5 @@
 plugins {
-    id 'nf-float@0.1.1'
+    id 'nf-float@0.1.2'
 }
 
 workDir = '/mnt/memverge/shared'

--- a/plugins/nf-float/src/main/com/memverge/nextflow/CmdResult.groovy
+++ b/plugins/nf-float/src/main/com/memverge/nextflow/CmdResult.groovy
@@ -75,16 +75,19 @@ class CmdResult {
     }
 
     Map getQStatus() {
-        def parser = new JsonSlurper()
-        def obj = parser.parseText(out)
-
         def ret = [:]
-        for (i in obj) {
-            def id = i.id as String
-            def status = i.status as String
-            if (id && status) {
-                ret[id] = status
+        try {
+            def parser = new JsonSlurper()
+            def obj = parser.parseText(out)
+            for (i in obj) {
+                def id = i.id as String
+                def status = i.status as String
+                if (id && status) {
+                    ret[id] = status
+                }
             }
+        } catch (Exception e) {
+            log.warn "failed to parse: ${out}, detail: ${e.toString()}"
         }
         return ret
     }

--- a/plugins/nf-float/src/main/com/memverge/nextflow/FloatGridExecutor.groovy
+++ b/plugins/nf-float/src/main/com/memverge/nextflow/FloatGridExecutor.groovy
@@ -9,6 +9,9 @@ import nextflow.util.ServiceName
 import org.apache.commons.lang.StringUtils
 
 import java.nio.file.Path
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.stream.Collectors
 
 /**
  * Float Executor with a shared file system
@@ -17,11 +20,8 @@ import java.nio.file.Path
 @ServiceName('float')
 @CompileStatic
 class FloatGridExecutor extends AbstractGridExecutor {
-
-    private FloatClient getClient() {
-        final factory = new FloatClientFactory(session.config)
-        return factory.getFloatClient()
-    }
+    private Map<String, String> job2oc = new ConcurrentHashMap<>()
+    private AtomicInteger serial = new AtomicInteger()
 
     private FloatConf getFloatConf() {
         return FloatConf.getConf(session.config)
@@ -44,13 +44,15 @@ class FloatGridExecutor extends AbstractGridExecutor {
         if (!config.nfs && !floatConf.nfs) {
             log.error '[float] missing "nfs": need a nfs to run float jobs'
         }
-        if (!config.image) {
+        if (!config.image && !config.container) {
             log.error '[float] missing "image": container image'
         }
         if (!config.cpu) {
-            log.info '[float] missing "cpus": number of cpu cores, use default'
+            if (!config.cpus) {
+                log.info '[float] missing "cpus": number of cpu cores, use default'
+            }
         }
-        if (!config.mem) {
+        if (!config.mem && !config.memory) {
             log.info '[float] missing "memory": size of memory in GB, use default'
         }
     }
@@ -77,11 +79,19 @@ class FloatGridExecutor extends AbstractGridExecutor {
         if (cpu) {
             return cpu.toString()
         }
+        cpu = task.config.cpus
+        if (cpu) {
+            return task.config.getCpus().toString()
+        }
         return floatConf.cpu
     }
 
     private String getImage(TaskRun task) {
         def image = task.config.image
+        if (image) {
+            return image.toString()
+        }
+        image = task.config.getContainer()
         if (image) {
             return image.toString()
         }
@@ -93,7 +103,11 @@ class FloatGridExecutor extends AbstractGridExecutor {
         if (mem) {
             return mem.toString()
         }
-        return floatConf.memGB
+        mem = task.config.getMemory()
+        if (mem) {
+            return task.config.getMemory().toGiga().toString()
+        }
+        return floatConf.memGB.toGiga().toString()
     }
 
     private Collection<String> getExtra(TaskRun task) {
@@ -104,13 +118,31 @@ class FloatGridExecutor extends AbstractGridExecutor {
             extra = common.trim() + " " + extra.trim()
         }
         def ret = extra.split('\\s+')
-        return ret.findAll {it.length() > 0}
+        return ret.findAll { it.length() > 0 }
+    }
+
+    private List<String> getCmdPrefixForJob(String jobID) {
+        def oc = job2oc.getOrDefault(jobID, floatConf.addresses[0])
+        return floatConf.getCliPrefix(oc)
+    }
+
+    /**
+     * Retrieve the prefix of the submit command.
+     * use round robin for multiple op-center
+     *
+     * @return
+     */
+    private List<String> getSubmitCmdPrefix() {
+        def i = serial.incrementAndGet()
+        def addresses = floatConf.addresses
+        def address = addresses[i % (addresses.size())]
+        return floatConf.getCliPrefix(address)
     }
 
     @Override
     List<String> getSubmitCommandLine(TaskRun task, Path scriptFile) {
         validateTaskConf(task.config)
-        def cmd = client.getCmdPrefix()
+        def cmd = getSubmitCmdPrefix()
         cmd << 'sbatch'
         cmd << '--dataVolume'
         cmd << getNfs(task)
@@ -139,20 +171,139 @@ class FloatGridExecutor extends AbstractGridExecutor {
         return CmdResult.with(text).jobID()
     }
 
+    /**
+     * Kill a grid job
+     *
+     * @param jobId The ID of the job to kill,
+     *        could be a string collection
+     */
+    @Override
+    void killTask(def jobId) {
+        def cmdList = killTaskCommands(jobId)
+        cmdList.parallelStream().map { cmd ->
+            def proc = new ProcessBuilder(cmd).redirectErrorStream(true).start()
+            proc.waitForOrKill(10_000)
+            def ret = proc.exitValue()
+            if (ret != 0) {
+                def m = """\
+                Unable to kill pending jobs
+                - cmd executed: ${cmd.join(' ')}
+                - exit status : $ret
+                - output      :
+                """.stripIndent()
+                m += proc.text.indent('  ')
+                log.debug(m)
+            }
+            return ret
+        }.collect()
+    }
+
+    /**
+     * The command to be used to kill a grid job
+     *
+     * @param jobId The job ID to be kill
+     * @return The command line to be used to kill the specified job
+     */
+    protected List<List<String>> killTaskCommands(def jobId) {
+        def jobIds
+        if (jobId instanceof Collection) {
+            jobIds = jobId
+        } else {
+            jobIds = [jobId]
+        }
+        List<List<String>> ret = []
+        jobIds.forEach {
+            def id = it.toString()
+            def cmd = getCmdPrefixForJob(id)
+            cmd << 'scancel'
+            cmd << '-j'
+            cmd << id
+            log.info "[float] cancel job: ${cmd.join(' ')}"
+            ret.add(cmd)
+        }
+        return ret
+    }
+
+    private List<String> getCmdPrefix0() {
+        def addresses = floatConf.addresses
+        def address = addresses.first()
+        return floatConf.getCliPrefix(address)
+    }
+
     @Override
     protected List<String> getKillCommand() {
-        def cmd = client.getCmdPrefix()
+        def cmd = getCmdPrefix0()
         cmd << 'scancel'
         cmd << '-j'
+        log.info "[float] cancel job: ${cmd.join(' ')}"
         return cmd
+    }
+
+    /**
+     * @return The status for all the scheduled and running jobs
+     */
+    @Override
+    protected Map<String, QueueStatus> getQueueStatus0(queue) {
+        Map<String, List<String>> cmdMap = queueStatusCommands()
+        if (cmdMap.size() == 0) {
+            return null
+        }
+        def ret = new ConcurrentHashMap<String, QueueStatus>()
+        cmdMap.entrySet().parallelStream().map { entry ->
+            def oc = entry.key
+            def cmd = entry.value
+            log.debug "[float] getting queue ${queue ? "($queue) " : ''}status > cmd: ${cmd.join(' ')}"
+            try {
+                final buf = new StringBuilder()
+                final process = new ProcessBuilder(cmd).redirectErrorStream(true).start()
+                final consumer = process.consumeProcessOutputStream(buf)
+                process.waitForOrKill(60_000)
+                final exit = process.exitValue(); consumer.join() // <-- make sure sync with the output consume #1045
+                final result = buf.toString()
+
+                if (exit == 0) {
+                    log.trace "[${name.toUpperCase()}] queue ${queue ? "($queue) " : ''}status > cmd exit: $exit\n$result"
+                    def status = parseQueueStatus(result)
+                    status.each { key, val ->
+                        ret[key] = val
+                        job2oc[key] = oc
+                    }
+                } else {
+                    def m = """\
+                [float] queue ${queue ? "($queue) " : ''}status cannot be fetched
+                - cmd executed: ${cmd.join(' ')}
+                - exit status : $exit
+                - output      :
+                """.stripIndent()
+                    m += result.indent('  ')
+                    log.warn1(m, firstOnly: true)
+                }
+            } catch (Exception e) {
+                log.warn "[${name.toUpperCase()}] failed to retrieve queue ${queue ? "($queue) " : ''}status -- See the log file for details", e
+            }
+        }.collect()
+        log.debug "[float] collecting job status completes."
+        return ret
+    }
+
+    protected Map<String, List<String>> queueStatusCommands() {
+        return floatConf.addresses.stream().collect(
+                Collectors.toMap(
+                        oc -> oc.toString(),
+                        oc -> getQueueCmdOfOC(oc.toString())))
     }
 
     @Override
     protected List<String> queueStatusCommand(Object queue) {
-        def cmd = client.getCmdPrefix()
+        return getQueueCmdOfOC()
+    }
+
+    private List<String> getQueueCmdOfOC(String oc = "") {
+        def cmd = floatConf.getCliPrefix(oc)
         cmd << 'squeue'
         cmd << '--format'
         cmd << 'json'
+        log.info "[float] query job status: ${cmd.join(' ')}"
         return cmd
     }
 

--- a/plugins/nf-float/src/resources/META-INF/MANIFEST.MF
+++ b/plugins/nf-float/src/resources/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Plugin-Class: com.memverge.nextflow.FloatPlugin
 Plugin-Id: nf-float
-Plugin-Version: 0.1.1
+Plugin-Version: 0.1.2
 Plugin-Provider: MemVerge Corp.
 Plugin-Requires: >=22.10.0

--- a/plugins/nf-float/src/test/com/memverge/nextflow/CmdResultTest.groovy
+++ b/plugins/nf-float/src/test/com/memverge/nextflow/CmdResultTest.groovy
@@ -98,26 +98,39 @@ class CmdResultTest extends Specification {
 
         when:
         res.out = """
-[
-    {
-        "id": "QPj8nsNWfLam6VQWbeGnp",                                                                                           
-        "name": "cactus-c5d.large",                                                                                              
-        "user": "admin",                                                                                                         
-        "imageID": "docker.io/memverge/cactus:latest",                                                                           
-        "status": "FailToExecute"                                                                                                                                                                                                                                                                                                                         
-    },
-    {
-        "id": "u5x3sSLe0p3OznGavmYu3",
-        "name": "cactus-t3a.medium",
-        "workingHost": "3.143.251.235 (2Core4GB/Spot)",
-        "user": "admin",
-        "imageID": "docker.io/memverge/cactus:latest",
-        "status": "Executing"
-    }
-]"""
-        then:
+        [
+            {
+                "id": "QPj8nsNWfLam6VQWbeGnp",                                                                                           
+                "name": "cactus-c5d.large",                                                                                              
+                "user": "admin",                                                                                                         
+                "imageID": "docker.io/memverge/cactus:latest",                                                                           
+                "status": "FailToExecute"                                                                                                                                                                                                                                                                                                                         
+            },
+            {
+                "id": "u5x3sSLe0p3OznGavmYu3",
+                "name": "cactus-t3a.medium",
+                "workingHost": "3.143.251.235 (2Core4GB/Spot)",
+                "user": "admin",
+                "imageID": "docker.io/memverge/cactus:latest",
+                "status": "Executing"
+            }
+        ]"""
         def stMap = res.getQStatus()
+
+        then:
         stMap['QPj8nsNWfLam6VQWbeGnp'] == "FailToExecute"
         stMap['u5x3sSLe0p3OznGavmYu3'] == "Executing"
+    }
+
+    def "get queue empty"() {
+        given:
+        def res = new CmdResult()
+
+        when:
+        res.out = """No jobs"""
+        def stMap = res.getQStatus()
+
+        then:
+        stMap.size() == 0
     }
 }

--- a/plugins/nf-float/src/test/com/memverge/nextflow/FloatConfTest.groovy
+++ b/plugins/nf-float/src/test/com/memverge/nextflow/FloatConfTest.groovy
@@ -1,0 +1,158 @@
+package com.memverge.nextflow
+
+import spock.lang.Specification
+
+class FloatConfTest extends Specification {
+    def "one op-center in the address"() {
+        given:
+        def conf = [
+                float: [address: "1.2.3.4"]
+        ]
+
+        when:
+        def fConf = FloatConf.getConf(conf)
+
+        then:
+        fConf.addresses == ["1.2.3.4"]
+    }
+
+    def "2 op-centers in the address"() {
+        given:
+        def conf = [
+                float: [address: "1.2.3.4,2.3.4.5"]
+        ]
+
+        when:
+        def fConf = FloatConf.getConf(conf)
+
+        then:
+        fConf.addresses == ["1.2.3.4", "2.3.4.5"]
+    }
+
+    def "get cli without address"() {
+        given:
+        def conf = [
+                float: [address : "1.2.3.4, 2.3.4.5",
+                        username: "admin",
+                        password: "password"]]
+
+        when:
+        def fConf = FloatConf.getConf(conf)
+
+        then:
+        fConf.getCli() == "float -a 1.2.3.4 " +
+                "-u admin -p password"
+
+    }
+
+    def "get cli with address"() {
+        given:
+        def conf = [
+                float: [address : "1.2.3.4, 2.3.4.5",
+                        username: "admin",
+                        password: "password"]]
+
+        when:
+        def fConf = FloatConf.getConf(conf)
+
+        then:
+        fConf.getCli("1.1.1.1") == "float -a 1.1.1.1 " +
+                "-u admin -p password"
+    }
+
+    def "get memory from mem" () {
+        given:
+        def conf = [
+                float: [mem: 5]]
+
+        when:
+        def fConf = FloatConf.getConf(conf)
+
+        then:
+        fConf.memGB.toGiga() == 5
+    }
+
+    def "get memory from memory" () {
+        given:
+        def conf = [
+                float: [memory: '3 GB']]
+
+        when:
+        def fConf = FloatConf.getConf(conf)
+
+        then:
+        fConf.memGB.toGiga() == 3
+    }
+
+    def "get default memory" () {
+        given:
+        def conf = [
+                float: []]
+
+        when:
+        def fConf = FloatConf.getConf(conf)
+
+        then:
+        fConf.memGB.toGiga() == 4
+    }
+
+    def "get cpu from cpu" () {
+        given:
+        def conf = [
+                float: [cpu: 5]]
+
+        when:
+        def fConf = FloatConf.getConf(conf)
+
+        then:
+        fConf.cpu == '5'
+    }
+
+    def "get cpu from cpus" () {
+        given:
+        def conf = [
+                float: [cpus: 7]]
+
+        when:
+        def fConf = FloatConf.getConf(conf)
+
+        then:
+        fConf.cpu == '7'
+    }
+
+    def "get default cpu" () {
+        given:
+        def conf = [
+                float: []]
+
+        when:
+        def fConf = FloatConf.getConf(conf)
+
+        then:
+        fConf.cpu == '2'
+    }
+
+    def "get image from image" () {
+        given:
+        def conf = [
+                float: [image: 'a']]
+
+        when:
+        def fConf = FloatConf.getConf(conf)
+
+        then:
+        fConf.image == 'a'
+    }
+
+    def "get image from container" () {
+        given:
+        def conf = [
+                float: [container: 'b']]
+
+        when:
+        def fConf = FloatConf.getConf(conf)
+
+        then:
+        fConf.image == 'b'
+    }
+}

--- a/plugins/nf-float/src/test/com/memverge/nextflow/FloatGridExecutorMultiOCTest.groovy
+++ b/plugins/nf-float/src/test/com/memverge/nextflow/FloatGridExecutorMultiOCTest.groovy
@@ -1,0 +1,71 @@
+package com.memverge.nextflow
+
+import nextflow.Session
+import nextflow.processor.TaskConfig
+import nextflow.processor.TaskRun
+import spock.lang.Specification
+
+import java.nio.file.Paths
+
+class FloatGridExecutorMultiOCTest extends Specification {
+    def addr = 'fa, fb,'
+    def user = 'admin'
+    def pass = 'password'
+    def nfs = 'nfs://a.b.c'
+    def cpu = 5
+    def mem = 10
+    def image = 'cactus'
+    def script = '/path/job.sh'
+
+    def "submit job with round robin"() {
+        given:
+        def exec = [:] as FloatGridExecutor
+        def sess = [:] as Session
+
+        sess.config = [float: [address : addr,
+                               username: user,
+                               password: pass]]
+        def dataVol = nfs + ':/data'
+        def task = [:] as TaskRun
+        def config = [nfs  : dataVol,
+                      cpu  : cpu,
+                      mem  : mem,
+                      image: image] as TaskConfig
+
+        when:
+        exec.session = sess
+        task.config = config
+        def cmd1 = exec.getSubmitCommandLine(task, Paths.get(script))
+        def cmd2 = exec.getSubmitCommandLine(task, Paths.get(script))
+
+        then:
+        cmd1.join(' ') == "float -a fb -u admin -p password sbatch " +
+                "--dataVolume ${dataVol} --image ${image} " +
+                "--cpu ${cpu} --mem ${mem} --job ${script}"
+        cmd2.join(' ') == "float -a fa -u admin -p password sbatch " +
+                "--dataVolume ${dataVol} --image ${image} " +
+                "--cpu ${cpu} --mem ${mem} --job ${script}"
+    }
+
+    def "get queue status commands"() {
+        given:
+        def exec = [:] as FloatGridExecutor
+        def sess = [:] as Session
+
+        sess.config = [float: [address : addr,
+                               username: user,
+                               password: pass]]
+
+        when:
+        exec.session = sess
+        def cmdMap = exec.queueStatusCommands()
+        def cmd1 = cmdMap['fa']
+        def cmd2 = cmdMap['fb']
+
+        then:
+        cmd1.join(' ') == "float -a fa -u ${user} -p ${pass} " +
+                "squeue --format json"
+        cmd2.join(' ') == "float -a fb -u ${user} -p ${pass} " +
+                "squeue --format json"
+    }
+}


### PR DESCRIPTION
Allow user to specify multiple op-centers in the address field. Separate the address with `,`.

Support default instance options in NextFlow such as:
* `cpus` - an integer for CPU cores
* `memory` - a string form the size of memory
* `container` - name of the container image.