### PR TITLE
[GH-13] check `.exitcode` in output dir.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,16 +42,16 @@ Go to the folder where you just install the `nextflow` command line.
 Let's call this folder the Nextflow home directory.
 Create the float plugin folder with:
 ```
-mkdir -p .nextflow/plugins/nf-float-0.1.4
+mkdir -p .nextflow/plugins/nf-float-0.1.5
 ```
-where `0.1.4` is the version of the float plugin.  This version number should 
+where `0.1.5` is the version of the float plugin.  This version number should 
 align with the version in of your plugin and the property in your configuration
 file. (check the configuration section)
 
 Retrieve your plugin zip file and unzip it in this folder.
 If everything goes right, you should be able to see two sub-folders:
 ```
-$ ll .nextflow/plugins/nf-float-0.1.4/
+$ ll .nextflow/plugins/nf-float-0.1.5/
 total 48
 drwxr-xr-x 4 ec2-user ec2-user    51 Jan  5 07:17 classes
 drwxr-xr-x 2 ec2-user ec2-user    25 Jan  5 07:17 META-INF
@@ -64,7 +64,7 @@ file with the command line option `-c`.  Here is a sample of the configuration.
 
 ```
 plugins {
-    id 'nf-float@0.1.4'
+    id 'nf-float@0.1.5'
 }
 
 workDir = '/mnt/memverge/shared'

--- a/conf/float-rt.conf
+++ b/conf/float-rt.conf
@@ -1,5 +1,5 @@
 plugins {
-    id 'nf-float@0.1.4'
+    id 'nf-float@0.1.5'
 }
 
 workDir = '/mnt/memverge/shared'

--- a/plugins/nf-float/src/main/com/memverge/nextflow/FloatJobs.groovy
+++ b/plugins/nf-float/src/main/com/memverge/nextflow/FloatJobs.groovy
@@ -88,23 +88,18 @@ class FloatJobs {
             if (StringUtils.length(workDir) == 0) {
                 return
             }
+            def files = ['.command.out', '.command.err', '.exitcode']
             if (currentSt != Completed && st == Completed) {
-                def outName = Paths.get(workDir, ".command.out").toString()
-                def errName = Paths.get(workDir, ".command.err").toString()
-
-                File out = new File(outName)
-                File err = new File(errName)
-                if (!out.exists()) {
-                    log.warn("job $jobID completed but file not found: " +
-                            outName)
-                    return
+                for (filename in files) {
+                    def name = Paths.get(workDir, filename).toString()
+                    def file = new File(name)
+                    if (!file.exists()) {
+                        log.warn("job $jobID completed " +
+                                "but file not found: $filename")
+                        return
+                    }
                 }
-                if (!err.exists()) {
-                    log.warn("job $jobID completed but file not found: " +
-                            errName)
-                    return
-                }
-                log.info("found stdout & stderr in: $workDir")
+                log.info("found $files in: $workDir")
             }
             job2status.put(jobID, st)
         }

--- a/plugins/nf-float/src/resources/META-INF/MANIFEST.MF
+++ b/plugins/nf-float/src/resources/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Plugin-Class: com.memverge.nextflow.FloatPlugin
 Plugin-Id: nf-float
-Plugin-Version: 0.1.4
+Plugin-Version: 0.1.5
 Plugin-Provider: MemVerge Corp.
 Plugin-Requires: >=22.10.0


### PR DESCRIPTION
When we use s3fs, sometimes the task finished but the result file
 has not been synchronized to the local system. In the check
 status function, we should make sure all the file (including
.command.out, .command.std, .exitcode) are available before we mark the task completes.