### PR TITLE
[GH-4] List the dir. before we check files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,16 +42,16 @@ Go to the folder where you just install the `nextflow` command line.
 Let's call this folder the Nextflow home directory.
 Create the float plugin folder with:
 ```
-mkdir -p .nextflow/plugins/nf-float-0.1.5
+mkdir -p .nextflow/plugins/nf-float-0.1.6
 ```
-where `0.1.5` is the version of the float plugin.  This version number should 
+where `0.1.6` is the version of the float plugin.  This version number should 
 align with the version in of your plugin and the property in your configuration
 file. (check the configuration section)
 
 Retrieve your plugin zip file and unzip it in this folder.
 If everything goes right, you should be able to see two sub-folders:
 ```
-$ ll .nextflow/plugins/nf-float-0.1.5/
+$ ll .nextflow/plugins/nf-float-0.1.6/
 total 48
 drwxr-xr-x 4 ec2-user ec2-user    51 Jan  5 07:17 classes
 drwxr-xr-x 2 ec2-user ec2-user    25 Jan  5 07:17 META-INF
@@ -64,7 +64,7 @@ file with the command line option `-c`.  Here is a sample of the configuration.
 
 ```
 plugins {
-    id 'nf-float@0.1.5'
+    id 'nf-float@0.1.6'
 }
 
 workDir = '/mnt/memverge/shared'

--- a/conf/float-rt.conf
+++ b/conf/float-rt.conf
@@ -1,5 +1,5 @@
 plugins {
-    id 'nf-float@0.1.5'
+    id 'nf-float@0.1.6'
 }
 
 workDir = '/mnt/memverge/shared'

--- a/plugins/nf-float/src/main/com/memverge/nextflow/FloatJobs.groovy
+++ b/plugins/nf-float/src/main/com/memverge/nextflow/FloatJobs.groovy
@@ -88,6 +88,8 @@ class FloatJobs {
             if (StringUtils.length(workDir) == 0) {
                 return
             }
+            // call list files to update the folder cache
+            new File(workDir).listFiles()
             def files = ['.command.out', '.command.err', '.exitcode']
             if (currentSt != Completed && st == Completed) {
                 for (filename in files) {
@@ -95,7 +97,7 @@ class FloatJobs {
                     def file = new File(name)
                     if (!file.exists()) {
                         log.warn("job $jobID completed " +
-                                "but file not found: $filename")
+                                "but file not found: $name")
                         return
                     }
                 }

--- a/plugins/nf-float/src/resources/META-INF/MANIFEST.MF
+++ b/plugins/nf-float/src/resources/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Plugin-Class: com.memverge.nextflow.FloatPlugin
 Plugin-Id: nf-float
-Plugin-Version: 0.1.5
+Plugin-Version: 0.1.6
 Plugin-Provider: MemVerge Corp.
 Plugin-Requires: >=22.10.0


### PR DESCRIPTION
The `s3fs` doesn't update the directory cache unless we issue a read opration to the directory.
In the plugin, call list directory before we check the existance of the required files.

Upgrade the version to 0.1.6