### PR TITLE
[PER-44] NoAvailableHost exit code 143

### DIFF
--- a/plugins/nf-float/src/main/com/memverge/nextflow/FloatGridExecutor.groovy
+++ b/plugins/nf-float/src/main/com/memverge/nextflow/FloatGridExecutor.groovy
@@ -632,6 +632,7 @@ fi
         STATUS_MAP.put(FloatStatus.PENDING, QueueStatus.PENDING)
         STATUS_MAP.put(FloatStatus.RUNNING, QueueStatus.RUNNING)
         STATUS_MAP.put(FloatStatus.DONE, QueueStatus.DONE)
+        STATUS_MAP.put(FloatStatus.NOAVAILABLEHOST, QueueStatus.ERROR)
         STATUS_MAP.put(FloatStatus.ERROR, QueueStatus.ERROR)
         STATUS_MAP.put(FloatStatus.UNKNOWN, QueueStatus.UNKNOWN)
     }

--- a/plugins/nf-float/src/main/com/memverge/nextflow/FloatJob.groovy
+++ b/plugins/nf-float/src/main/com/memverge/nextflow/FloatJob.groovy
@@ -24,6 +24,7 @@ enum FloatStatus {
     PENDING,
     RUNNING,
     DONE,
+    NOAVAILABLEHOST,
     ERROR,
     UNKNOWN,
 
@@ -46,7 +47,7 @@ enum FloatStatus {
             'CheckpointFailed' : ERROR,
             'WaitingForLicense': ERROR,
             'Timedout'         : ERROR,
-            'NoAvailableHost'  : ERROR,
+            'NoAvailableHost'  : NOAVAILABLEHOST,
             'Unknown'          : UNKNOWN,
     ]
 
@@ -58,12 +59,8 @@ enum FloatStatus {
         return this == PENDING || this == RUNNING
     }
 
-    boolean isFinished() {
-        return this == ERROR || this == DONE
-    }
-
-    boolean isError() {
-        return this == ERROR
+    boolean isDoneOrFailed() {
+        return this == DONE || this == ERROR || this == NOAVAILABLEHOST
     }
 }
 
@@ -125,8 +122,8 @@ class FloatJob {
         return status ? status.isRunning() : false
     }
 
-    boolean isFinished() {
-        return status ? status.isFinished() : false
+    boolean isDoneOrFailed() {
+        return status ? status.isDoneOrFailed() : false
     }
 
     static List<FloatJob> parseJobMap(String input) {

--- a/plugins/nf-float/src/main/com/memverge/nextflow/FloatJobs.groovy
+++ b/plugins/nf-float/src/main/com/memverge/nextflow/FloatJobs.groovy
@@ -44,7 +44,7 @@ class FloatJobs {
     }
 
     TaskId getTaskID(String floatJobID) {
-        // go through the all float jobs to find the task id
+        // go through all float jobs to find the task id
         for (FloatJob job : nfJobID2FloatJob.values()) {
             if (job.floatJobID == floatJobID) {
                 // extract the task id from the nfJobID
@@ -74,7 +74,7 @@ class FloatJobs {
             log.error "[FLOAT] job nf Job ID is null or empty for job ${job.floatJobID}"
         } else {
             FloatJob existingJob = nfJobID2FloatJob.get(job.nfJobID)
-            if (existingJob != null && existingJob.finished) {
+            if (existingJob != null && existingJob.doneOrFailed) {
                 log.info "[FLOAT] job ${job.nfJobID} already finished, no need to update"
                 job = existingJob
             } else {
@@ -83,7 +83,7 @@ class FloatJobs {
                 }
                 nfJobID2FloatJob.put(job.nfJobID, job)
             }
-            if (job.finished) {
+            if (job.doneOrFailed) {
                 refreshWorkDir(job.nfJobID)
             }
         }

--- a/plugins/nf-float/src/main/com/memverge/nextflow/FloatTaskHandler.groovy
+++ b/plugins/nf-float/src/main/com/memverge/nextflow/FloatTaskHandler.groovy
@@ -73,8 +73,8 @@ class FloatTaskHandler extends GridTaskHandler {
     boolean checkIfCompleted() {
         final FloatStatus st =  floatExecutor.getJobStatus(task)
         log.debug "got status ${st} for ${task.id} from float executor"
-        if (st.finished) {
-            status = COMPLETED
+        if (st.doneOrFailed) {
+            this.status = COMPLETED
             task.exitStatus = readExitStatus()
             if (task.exitStatus == null) {
                 log.debug "can't get ${task.id} exit status from file system"
@@ -82,11 +82,16 @@ class FloatTaskHandler extends GridTaskHandler {
             }
             log.debug "set ${task.id} exit status to ${task.exitStatus}"
             if (task.exitStatus == null) {
-                if (st.isError()) {
+                task.exitStatus = 0
+
+                if (st == FloatStatus.ERROR) {
                     task.exitStatus = 1
-                } else {
-                    task.exitStatus = 0
                 }
+
+                if (st == FloatStatus.NOAVAILABLEHOST) {
+                    task.exitStatus = 143
+                }
+
                 log.info "both .exitcode and rc are empty for ${task.id}," +
                         "set exit to ${task.exitStatus}"
             }

--- a/plugins/nf-float/src/resources/META-INF/MANIFEST.MF
+++ b/plugins/nf-float/src/resources/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Plugin-Class: com.memverge.nextflow.FloatPlugin
 Plugin-Id: nf-float
-Plugin-Version: 0.4.7
+Plugin-Version: 0.4.8
 Plugin-Provider: MemVerge Corp.
 Plugin-Requires: >=23.04.0

--- a/plugins/nf-float/src/test/com/memverge/nextflow/FloatJobTest.groovy
+++ b/plugins/nf-float/src/test/com/memverge/nextflow/FloatJobTest.groovy
@@ -127,6 +127,69 @@ class FloatJobTest extends Specification {
         job.status == FloatStatus.PENDING
     }
 
+    def "check job failed with NoAvailableHost"() {
+        given:
+        final out = """
+            id: uqaj8l6a407u88v0106ol
+            name: subread-3nyw14-r6a.2xlarge
+            workingHost: ""
+            category: failed
+            status: NoAvailableHost
+            cpu: 8
+            duration: 1h5m49s
+            queueTime: 0s
+            submitTime: "2025-06-20T09:09:34Z"
+            execTime: "2025-06-20T09:09:34Z"
+            endTime: "2025-06-20T10:15:23Z"
+            lastUpdate: "2025-06-20T10:15:23Z"
+            memGB: 64
+            scheduler: mmcloud
+            imageID: quay.io/biocontainers/subread:2.0.6--he4a0461_2
+            stdout: stdout.autosave
+            stderr: stderr.autosave
+            memUsed: 0.00 B
+            cpuMax: 24
+            memGBMax: 144
+            instanceType: r6a.2xlarge
+            coreHours: 0.6784628924888889
+            """.stripIndent().trim()
+
+        when:
+        final job = FloatJob.parse(out)
+
+        then:
+        ! job.isRunning()
+        job.status == FloatStatus.NOAVAILABLEHOST
+    }
+
+    def "check job failed with FailToExecute"() {
+        given:
+        final out = """
+            id: 3cfmkg882qn09q9o8jfkf
+            name: rseqc-2609uc-m5zn.3xlarge
+            workingHost: ""
+            category: failed
+            status: FailToExecute
+            cpu: 6
+            duration: 0s
+            queueTime: 0s
+            submitTime: "2025-06-20T09:13:54Z"
+            execTime: "2025-06-20T09:13:54Z"
+            endTime: "2025-06-20T09:13:55Z"
+            lastUpdate: "2025-06-20T09:13:55Z"
+            memGB: 36
+            cpuMax: 24
+            memGBMax: 144
+            """.stripIndent().trim()
+
+        when:
+        final job = FloatJob.parse(out)
+
+        then:
+        ! job.isRunning()
+        job.status == FloatStatus.ERROR
+    }
+
     def "get queue status"() {
         given:
         final out = """


### PR DESCRIPTION
By changing the exit code for `NoAvailableHost` to `143`, we can configure Nextflow to retry with backoff during low spot availability. The recommended error strategy is,

```groovy
process {
    errorStrategy = {
        if ( task.exitStatus == 143 ) { // NoAvailableHost
            sleep(Math.pow(2, task.attempt) * 2 * 60000 as long)
            return 'retry'
        }
  
        task.exitStatus in ((130..142) + 145 + 104 + 175)
        ? 'retry'
        : 'finish'
    }
    maxRetries = 5
}
```